### PR TITLE
feat(security): protect promoter endpoints and externalize admin cred…

### DIFF
--- a/src/main/java/com/gresk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/gresk/infrastructure/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.gresk.infrastructure.config;
 
 import com.gresk.infrastructure.security.JwtAuthenticationFilter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -22,6 +23,9 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Value("${gresk.cors.allowed-origins}")
+    private List<String> allowedOrigins;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
@@ -54,7 +58,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOriginPatterns(List.of("http://localhost:*"));
+        config.setAllowedOriginPatterns(allowedOrigins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(false);

--- a/src/main/java/com/gresk/infrastructure/seed/AdminAccountSeeder.java
+++ b/src/main/java/com/gresk/infrastructure/seed/AdminAccountSeeder.java
@@ -7,52 +7,56 @@ import com.gresk.shared.domain.AccountStatus;
 import com.gresk.shared.domain.Role;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
 import java.util.UUID;
 
-/**
- * Crea la cuenta de admin por defecto al arrancar la aplicación,
- * si no existe ninguna cuenta con rol ADMIN.
- *
- * Credenciales por defecto:
- *   email:    admin@gresk.com
- *   password: admin123  (BCrypt — hash generado en runtime)
- */
 @Slf4j
 @Component
+@Profile("dev")
 @RequiredArgsConstructor
 public class AdminAccountSeeder {
-
-    private static final String ADMIN_EMAIL    = "admin@gresk.com";
-    private static final String ADMIN_PASSWORD = "admin123";
 
     private final AccountJpaRepository accountJpaRepository;
     private final PasswordHasherPort   passwordHasher;
 
+    @Value("${ADMIN_EMAIL:#{null}}")
+    @Nullable
+    private String adminEmail;
+
+    @Value("${ADMIN_PASSWORD:#{null}}")
+    @Nullable
+    private String adminPassword;
+
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void seed() {
+        if (adminEmail == null || adminPassword == null) {
+            log.warn("[AdminSeeder] ADMIN_EMAIL or ADMIN_PASSWORD not set — skipping admin creation.");
+            return;
+        }
+
         if (accountJpaRepository.existsByRolesContaining(Role.ADMIN)) {
             log.info("[AdminSeeder] Admin account already exists — skipping.");
             return;
         }
 
-        String hash = passwordHasher.hash(ADMIN_PASSWORD);
-
         AccountEntity admin = AccountEntity.builder()
                 .id(UUID.randomUUID())
-                .email(ADMIN_EMAIL)
-                .passwordHash(hash)
+                .email(adminEmail)
+                .passwordHash(passwordHasher.hash(adminPassword))
                 .status(AccountStatus.ACTIVE)
                 .roles(Set.of(Role.ADMIN))
                 .build();
 
         accountJpaRepository.save(admin);
-        log.info("[AdminSeeder] Default admin account created → {}", ADMIN_EMAIL);
+        log.info("[AdminSeeder] Admin account created → {}", adminEmail);
     }
 }

--- a/src/main/java/com/gresk/modules/account/infrastructure/persistence/AccountStatusAdapter.java
+++ b/src/main/java/com/gresk/modules/account/infrastructure/persistence/AccountStatusAdapter.java
@@ -1,0 +1,23 @@
+package com.gresk.modules.account.infrastructure.persistence;
+
+import com.gresk.modules.account.domain.exception.AccountNotFoundException;
+import com.gresk.shared.domain.AccountStatus;
+import com.gresk.shared.domain.port.out.AccountStatusPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class AccountStatusAdapter implements AccountStatusPort {
+
+    private final AccountJpaRepository jpaRepository;
+
+    @Override
+    public AccountStatus getStatus(UUID accountId) {
+        return jpaRepository.findById(accountId)
+                .map(AccountEntity::getStatus)
+                .orElseThrow(() -> new AccountNotFoundException(accountId.toString()));
+    }
+}

--- a/src/main/java/com/gresk/modules/event/application/usecase/CreateEventUseCase.java
+++ b/src/main/java/com/gresk/modules/event/application/usecase/CreateEventUseCase.java
@@ -2,8 +2,11 @@ package com.gresk.modules.event.application.usecase;
 
 import com.gresk.modules.event.domain.model.*;
 import com.gresk.modules.event.domain.port.out.EventRepository;
+import com.gresk.modules.promoter.domain.exception.PromoterNotActiveException;
 import com.gresk.modules.promoter.domain.model.valueobject.PromoterId;
+import com.gresk.shared.domain.AccountStatus;
 import com.gresk.shared.domain.MusicGenre;
+import com.gresk.shared.domain.port.out.AccountStatusPort;
 import com.gresk.shared.domain.port.out.ImageStoragePort;
 import com.gresk.shared.domain.valueobject.Address;
 import com.gresk.shared.domain.valueobject.City;
@@ -23,9 +26,15 @@ public class CreateEventUseCase {
 
     private final EventRepository eventRepository;
     private final ImageStoragePort imageStorage;
+    private final AccountStatusPort accountStatusPort;
 
     @Transactional
     public Event execute(CreateEventCommand command) {
+        UUID accountId = UUID.fromString(command.promoterId());
+        if (accountStatusPort.getStatus(accountId) != AccountStatus.ACTIVE) {
+            throw new PromoterNotActiveException("Promoter account is not active: " + accountId);
+        }
+
         PromoterId promoterId = PromoterId.of(command.promoterId());
         Event event = Event.create(command.title(), promoterId);
 

--- a/src/main/java/com/gresk/modules/event/application/usecase/PublishEventUseCase.java
+++ b/src/main/java/com/gresk/modules/event/application/usecase/PublishEventUseCase.java
@@ -8,10 +8,15 @@ import com.gresk.modules.event.domain.exception.ForbiddenOperationException;
 import com.gresk.modules.event.domain.model.Event;
 import com.gresk.modules.event.domain.model.EventId;
 import com.gresk.modules.event.domain.port.out.EventRepository;
+import com.gresk.modules.promoter.domain.exception.PromoterNotActiveException;
 import com.gresk.modules.promoter.domain.model.valueobject.PromoterId;
+import com.gresk.shared.domain.AccountStatus;
+import com.gresk.shared.domain.port.out.AccountStatusPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -19,9 +24,15 @@ public class PublishEventUseCase {
 
     private final EventRepository      eventRepository;
     private final ArtistRepositoryPort artistRepository;
+    private final AccountStatusPort    accountStatusPort;
 
     @Transactional
     public Event execute(String eventId, String requesterId) {
+        UUID accountId = UUID.fromString(requesterId);
+        if (accountStatusPort.getStatus(accountId) != AccountStatus.ACTIVE) {
+            throw new PromoterNotActiveException("Promoter account is not active: " + accountId);
+        }
+
         EventId id = EventId.of(eventId);
         PromoterId requester = PromoterId.of(requesterId);
 

--- a/src/main/java/com/gresk/modules/promoter/application/usecase/GetPromoterByAccountIdUseCase.java
+++ b/src/main/java/com/gresk/modules/promoter/application/usecase/GetPromoterByAccountIdUseCase.java
@@ -2,10 +2,13 @@ package com.gresk.modules.promoter.application.usecase;
 
 import com.gresk.modules.promoter.application.dto.PromoterProfileDTO;
 import com.gresk.modules.promoter.application.port.in.GetPromoterByAccountIdPort;
+import com.gresk.modules.promoter.domain.exception.PromoterNotActiveException;
 import com.gresk.modules.promoter.domain.exception.PromoterNotFoundException;
 import com.gresk.modules.promoter.domain.model.Promoter;
 import com.gresk.modules.promoter.domain.model.valueobject.PromoterId;
 import com.gresk.modules.promoter.domain.port.out.PromoterRepositoryPort;
+import com.gresk.shared.domain.AccountStatus;
+import com.gresk.shared.domain.port.out.AccountStatusPort;
 import com.gresk.shared.domain.port.out.ImageUrlResolverPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,9 +22,14 @@ public class GetPromoterByAccountIdUseCase implements GetPromoterByAccountIdPort
 
     private final PromoterRepositoryPort promoterRepository;
     private final ImageUrlResolverPort imageUrlResolver;
+    private final AccountStatusPort accountStatusPort;
 
     @Override
     public PromoterProfileDTO execute(UUID accountId) {
+        if (accountStatusPort.getStatus(accountId) != AccountStatus.ACTIVE) {
+            throw new PromoterNotActiveException("Promoter account is not active: " + accountId);
+        }
+
         PromoterId id = PromoterId.of(accountId.toString());
 
         Promoter promoter = promoterRepository.findById(id)

--- a/src/main/java/com/gresk/modules/promoter/application/usecase/GetPromoterDashboardUseCase.java
+++ b/src/main/java/com/gresk/modules/promoter/application/usecase/GetPromoterDashboardUseCase.java
@@ -2,12 +2,15 @@ package com.gresk.modules.promoter.application.usecase;
 
 import com.gresk.modules.promoter.application.dto.PromoterDashboardDTO;
 import com.gresk.modules.promoter.application.port.in.GetPromoterDashboardPort;
+import com.gresk.modules.promoter.domain.exception.PromoterNotActiveException;
 import com.gresk.modules.promoter.domain.exception.PromoterNotFoundException;
 import com.gresk.modules.promoter.domain.model.Promoter;
 import com.gresk.modules.promoter.domain.model.valueobject.PromoterId;
 import com.gresk.modules.promoter.domain.model.valueobject.PromoterStats;
 import com.gresk.modules.promoter.domain.port.out.PromoterRepositoryPort;
 import com.gresk.modules.promoter.domain.port.out.PromoterStatsProviderPort;
+import com.gresk.shared.domain.AccountStatus;
+import com.gresk.shared.domain.port.out.AccountStatusPort;
 import com.gresk.shared.domain.port.out.ImageUrlResolverPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,9 +25,14 @@ public class GetPromoterDashboardUseCase implements GetPromoterDashboardPort {
     private final PromoterRepositoryPort promoterRepository;
     private final PromoterStatsProviderPort statsProvider;
     private final ImageUrlResolverPort imageUrlResolver;
+    private final AccountStatusPort accountStatusPort;
 
     @Override
     public PromoterDashboardDTO execute(UUID accountId) {
+        if (accountStatusPort.getStatus(accountId) != AccountStatus.ACTIVE) {
+            throw new PromoterNotActiveException("Promoter account is not active: " + accountId);
+        }
+
         PromoterId id = PromoterId.of(accountId.toString());
 
         Promoter promoter = promoterRepository.findById(id)

--- a/src/main/java/com/gresk/modules/promoter/application/usecase/UpdatePromoterProfileUseCase.java
+++ b/src/main/java/com/gresk/modules/promoter/application/usecase/UpdatePromoterProfileUseCase.java
@@ -2,10 +2,13 @@ package com.gresk.modules.promoter.application.usecase;
 
 import com.gresk.modules.promoter.application.command.UpdatePromoterProfileCommand;
 import com.gresk.modules.promoter.application.port.in.UpdatePromoterProfilePort;
+import com.gresk.modules.promoter.domain.exception.PromoterNotActiveException;
 import com.gresk.modules.promoter.domain.exception.PromoterNotFoundException;
 import com.gresk.modules.promoter.domain.model.Promoter;
 import com.gresk.modules.promoter.domain.port.out.PromoterRepositoryPort;
+import com.gresk.shared.domain.AccountStatus;
 import com.gresk.shared.domain.MusicGenre;
+import com.gresk.shared.domain.port.out.AccountStatusPort;
 import com.gresk.shared.domain.valueobject.Address;
 import com.gresk.shared.domain.valueobject.City;
 import com.gresk.shared.domain.valueobject.Description;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,10 +28,16 @@ import java.util.stream.Collectors;
 public class UpdatePromoterProfileUseCase implements UpdatePromoterProfilePort {
 
     private final PromoterRepositoryPort promoterRepository;
+    private final AccountStatusPort accountStatusPort;
 
     @Transactional
     @Override
     public void execute(UpdatePromoterProfileCommand command) {
+        UUID accountId = UUID.fromString(command.promoterId());
+        if (accountStatusPort.getStatus(accountId) != AccountStatus.ACTIVE) {
+            throw new PromoterNotActiveException("Promoter account is not active: " + accountId);
+        }
+
         PromoterId id = PromoterId.of(command.promoterId());
         Promoter promoter = promoterRepository.findById(id)
                 .orElseThrow(() -> new PromoterNotFoundException(command.promoterId()));

--- a/src/main/java/com/gresk/modules/promoter/domain/exception/PromoterNotActiveException.java
+++ b/src/main/java/com/gresk/modules/promoter/domain/exception/PromoterNotActiveException.java
@@ -1,0 +1,7 @@
+package com.gresk.modules.promoter.domain.exception;
+
+public class PromoterNotActiveException extends RuntimeException {
+    public PromoterNotActiveException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gresk/shared/domain/port/out/AccountStatusPort.java
+++ b/src/main/java/com/gresk/shared/domain/port/out/AccountStatusPort.java
@@ -1,0 +1,9 @@
+package com.gresk.shared.domain.port.out;
+
+import com.gresk.shared.domain.AccountStatus;
+
+import java.util.UUID;
+
+public interface AccountStatusPort {
+    AccountStatus getStatus(UUID accountId);
+}

--- a/src/main/java/com/gresk/shared/infrastructure/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/gresk/shared/infrastructure/web/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.gresk.shared.infrastructure.web;
 import com.gresk.modules.account.domain.exception.AccountAlreadyExistsException;
 import com.gresk.modules.account.domain.exception.InvalidAccountCredentialsException;
 import com.gresk.modules.promoter.domain.exception.*;
+import com.gresk.modules.promoter.domain.exception.PromoterNotActiveException;
 import com.gresk.modules.user.domain.exception.UserNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -33,6 +34,11 @@ public class GlobalExceptionHandler {
     }
 
     // Promoter exceptions
+    @ExceptionHandler(PromoterNotActiveException.class)
+    ResponseEntity<Map<String, String>> handlePromoterNotActive(PromoterNotActiveException ex) {
+        return ResponseEntity.status(403).body(Map.of("error", ex.getMessage()));
+    }
+
     @ExceptionHandler(PromoterNotFoundException.class)
     ResponseEntity<Map<String, String>> handleNotFound(PromoterNotFoundException ex) {
         return ResponseEntity.status(404).body(Map.of("error", ex.getMessage()));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,9 @@ cloudinary:
   api-secret: ${CLOUDINARY_API_SECRET}
 
 gresk:
+  cors:
+    allowed-origins:
+      - "http://localhost:*"
   images:
     default-url: "https://res.cloudinary.com/dzfgoh6hu/image/upload/c_fill,g_auto,w_1200,h_675/arde-bogota_98.jpg_bmbxtw.png"
     # Añadimos la extensión al final del template para asegurar que el navegador la lea bien


### PR DESCRIPTION
…entials

- Add AccountStatusPort to shared layer to avoid cross-module dependency
- Implement AccountStatusAdapter in account infrastructure
- Add PromoterNotActiveException to promoter domain (correct module)
- Check AccountStatus.ACTIVE in GetPromoterByAccountId, GetPromoterDashboard, UpdatePromoterProfile, CreateEvent and PublishEvent use cases
- Add 403 handler for PromoterNotActiveException in GlobalExceptionHandler
- Restrict AdminAccountSeeder to @Profile("dev"), read credentials from ADMIN_EMAIL / ADMIN_PASSWORD env vars via @Value (no hardcoded defaults)
- Externalize CORS origins to gresk.cors.allowed-origins in application.yml