### PR TITLE
feat(event): calendario de eventos del promotor con SOLD_OUT y heatmap

### DIFF
--- a/src/main/java/com/gresk/modules/event/application/dto/CalendarEventResponse.java
+++ b/src/main/java/com/gresk/modules/event/application/dto/CalendarEventResponse.java
@@ -1,0 +1,12 @@
+package com.gresk.modules.event.application.dto;
+
+public record CalendarEventResponse(
+        String id,
+        String title,
+        String eventDate,
+        String status,
+        int soldPercentage,
+        String genre,
+        String city,
+        String venue
+) {}

--- a/src/main/java/com/gresk/modules/event/application/dto/CalendarEventsResponse.java
+++ b/src/main/java/com/gresk/modules/event/application/dto/CalendarEventsResponse.java
@@ -1,0 +1,8 @@
+package com.gresk.modules.event.application.dto;
+
+import java.util.List;
+
+public record CalendarEventsResponse(
+        List<CalendarEventResponse> events,
+        int totalCount
+) {}

--- a/src/main/java/com/gresk/modules/event/application/dto/CalendarResponseMapper.java
+++ b/src/main/java/com/gresk/modules/event/application/dto/CalendarResponseMapper.java
@@ -1,0 +1,42 @@
+package com.gresk.modules.event.application.dto;
+
+import com.gresk.modules.event.domain.model.CalendarEvent;
+import com.gresk.modules.event.domain.model.HeatmapDay;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CalendarResponseMapper {
+
+    public CalendarEventResponse toResponse(CalendarEvent event) {
+        return new CalendarEventResponse(
+                event.id().value().toString(),
+                event.title(),
+                event.eventDate() != null ? event.eventDate().toString() : null,
+                event.status() != null ? event.status().name() : null,
+                event.soldPercentage(),
+                event.genre() != null ? event.genre().name() : null,
+                event.city(),
+                event.venue()
+        );
+    }
+
+    public CalendarEventsResponse toCalendarResponse(List<CalendarEvent> events) {
+        List<CalendarEventResponse> responses = events.stream().map(this::toResponse).toList();
+        return new CalendarEventsResponse(responses, responses.size());
+    }
+
+    public HeatmapDayResponse toDayResponse(HeatmapDay day) {
+        return new HeatmapDayResponse(
+                day.date().toString(),
+                day.eventCount(),
+                day.avgOccupationPercentage()
+        );
+    }
+
+    public HeatmapResponse toHeatmapResponse(int year, int month, List<HeatmapDay> days) {
+        List<HeatmapDayResponse> dayResponses = days.stream().map(this::toDayResponse).toList();
+        return new HeatmapResponse(year, month, dayResponses);
+    }
+}

--- a/src/main/java/com/gresk/modules/event/application/dto/HeatmapDayResponse.java
+++ b/src/main/java/com/gresk/modules/event/application/dto/HeatmapDayResponse.java
@@ -1,0 +1,7 @@
+package com.gresk.modules.event.application.dto;
+
+public record HeatmapDayResponse(
+        String date,
+        int eventCount,
+        int avgOccupationPercentage
+) {}

--- a/src/main/java/com/gresk/modules/event/application/dto/HeatmapResponse.java
+++ b/src/main/java/com/gresk/modules/event/application/dto/HeatmapResponse.java
@@ -1,0 +1,9 @@
+package com.gresk.modules.event.application.dto;
+
+import java.util.List;
+
+public record HeatmapResponse(
+        int year,
+        int month,
+        List<HeatmapDayResponse> days
+) {}

--- a/src/main/java/com/gresk/modules/event/application/query/CalendarEventsQuery.java
+++ b/src/main/java/com/gresk/modules/event/application/query/CalendarEventsQuery.java
@@ -1,0 +1,5 @@
+package com.gresk.modules.event.application.query;
+
+import java.time.Instant;
+
+public record CalendarEventsQuery(String promoterId, Instant from, Instant to) {}

--- a/src/main/java/com/gresk/modules/event/application/query/HeatmapQuery.java
+++ b/src/main/java/com/gresk/modules/event/application/query/HeatmapQuery.java
@@ -1,0 +1,3 @@
+package com.gresk.modules.event.application.query;
+
+public record HeatmapQuery(String promoterId, int year, int month) {}

--- a/src/main/java/com/gresk/modules/event/application/usecase/GetCalendarEventsUseCase.java
+++ b/src/main/java/com/gresk/modules/event/application/usecase/GetCalendarEventsUseCase.java
@@ -1,0 +1,24 @@
+package com.gresk.modules.event.application.usecase;
+
+import com.gresk.modules.event.application.query.CalendarEventsQuery;
+import com.gresk.modules.event.domain.model.CalendarEvent;
+import com.gresk.modules.event.domain.port.out.EventRepository;
+import com.gresk.modules.promoter.domain.model.valueobject.PromoterId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetCalendarEventsUseCase {
+
+    private final EventRepository eventRepository;
+
+    public List<CalendarEvent> execute(CalendarEventsQuery query) {
+        PromoterId promoterId = PromoterId.of(query.promoterId());
+        return eventRepository.findCalendarEventsByPromoter(promoterId, query.from(), query.to());
+    }
+}

--- a/src/main/java/com/gresk/modules/event/application/usecase/GetHeatmapUseCase.java
+++ b/src/main/java/com/gresk/modules/event/application/usecase/GetHeatmapUseCase.java
@@ -1,0 +1,53 @@
+package com.gresk.modules.event.application.usecase;
+
+import com.gresk.modules.event.application.query.HeatmapQuery;
+import com.gresk.modules.event.domain.model.CalendarEvent;
+import com.gresk.modules.event.domain.model.HeatmapDay;
+import com.gresk.modules.event.domain.port.out.EventRepository;
+import com.gresk.modules.promoter.domain.model.valueobject.PromoterId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetHeatmapUseCase {
+
+    private final EventRepository eventRepository;
+
+    public List<HeatmapDay> execute(HeatmapQuery query) {
+        YearMonth yearMonth = YearMonth.of(query.year(), query.month());
+        var from = yearMonth.atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        var to   = yearMonth.plusMonths(1).atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+        PromoterId promoterId = PromoterId.of(query.promoterId());
+        List<CalendarEvent> events = eventRepository.findCalendarEventsByPromoter(promoterId, from, to);
+
+        Map<LocalDate, List<CalendarEvent>> byDay = events.stream()
+                .collect(Collectors.groupingBy(e ->
+                        e.eventDate().atZone(ZoneOffset.UTC).toLocalDate()
+                ));
+
+        List<HeatmapDay> days = new ArrayList<>(yearMonth.lengthOfMonth());
+        for (int day = 1; day <= yearMonth.lengthOfMonth(); day++) {
+            LocalDate date = yearMonth.atDay(day);
+            List<CalendarEvent> dayEvents = byDay.getOrDefault(date, List.of());
+            int avgOccupation = dayEvents.isEmpty() ? 0 :
+                    (int) Math.round(dayEvents.stream()
+                            .mapToInt(CalendarEvent::soldPercentage)
+                            .average()
+                            .orElse(0));
+            days.add(new HeatmapDay(date, dayEvents.size(), avgOccupation));
+        }
+        return days;
+    }
+}

--- a/src/main/java/com/gresk/modules/event/domain/model/CalendarEvent.java
+++ b/src/main/java/com/gresk/modules/event/domain/model/CalendarEvent.java
@@ -1,0 +1,16 @@
+package com.gresk.modules.event.domain.model;
+
+import com.gresk.shared.domain.MusicGenre;
+
+import java.time.Instant;
+
+public record CalendarEvent(
+        EventId id,
+        String title,
+        Instant eventDate,
+        EventStatus status,
+        int soldPercentage,
+        MusicGenre genre,
+        String city,
+        String venue
+) {}

--- a/src/main/java/com/gresk/modules/event/domain/model/Event.java
+++ b/src/main/java/com/gresk/modules/event/domain/model/Event.java
@@ -138,6 +138,19 @@ public final class Event {
             throw new IllegalStateException("Event has no capacity set");
         }
         this.capacity = capacity.reserve(1);
+        if (this.capacity.available() == 0 && this.status == EventStatus.PUBLISHED) {
+            this.status = EventStatus.SOLD_OUT;
+        }
+    }
+
+    public void restoreCapacity() {
+        if (capacity == null) {
+            throw new IllegalStateException("Event has no capacity set");
+        }
+        this.capacity = new Capacity(capacity.total(), capacity.available() + 1);
+        if (this.status == EventStatus.SOLD_OUT) {
+            this.status = EventStatus.PUBLISHED;
+        }
     }
 
     /**

--- a/src/main/java/com/gresk/modules/event/domain/model/EventStatus.java
+++ b/src/main/java/com/gresk/modules/event/domain/model/EventStatus.java
@@ -5,6 +5,7 @@ import java.util.Set;
 public enum EventStatus {
     DRAFT,
     PUBLISHED,
+    SOLD_OUT,
     FINISHED,
     CANCELLED;
 
@@ -12,7 +13,8 @@ public enum EventStatus {
 
     static {
         DRAFT.allowedTargets     = Set.of(PUBLISHED, CANCELLED);
-        PUBLISHED.allowedTargets = Set.of(FINISHED, CANCELLED);
+        PUBLISHED.allowedTargets = Set.of(SOLD_OUT, FINISHED, CANCELLED);
+        SOLD_OUT.allowedTargets  = Set.of(PUBLISHED, FINISHED, CANCELLED);
         FINISHED.allowedTargets  = Set.of();
         CANCELLED.allowedTargets = Set.of();
     }

--- a/src/main/java/com/gresk/modules/event/domain/model/HeatmapDay.java
+++ b/src/main/java/com/gresk/modules/event/domain/model/HeatmapDay.java
@@ -1,0 +1,9 @@
+package com.gresk.modules.event.domain.model;
+
+import java.time.LocalDate;
+
+public record HeatmapDay(
+        LocalDate date,
+        int eventCount,
+        int avgOccupationPercentage
+) {}

--- a/src/main/java/com/gresk/modules/event/domain/port/out/EventRepository.java
+++ b/src/main/java/com/gresk/modules/event/domain/port/out/EventRepository.java
@@ -1,9 +1,12 @@
 package com.gresk.modules.event.domain.port.out;
 
+import com.gresk.modules.event.domain.model.CalendarEvent;
 import com.gresk.modules.event.domain.model.Event;
 import com.gresk.modules.event.domain.model.EventId;
+import com.gresk.modules.promoter.domain.model.valueobject.PromoterId;
 import org.springframework.data.domain.PageRequest;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +18,5 @@ public interface EventRepository {
     boolean     existsById(EventId id);
     List<Event> findLastMinute();
     List<Event> findEligibleForFlashDeal();
+    List<CalendarEvent> findCalendarEventsByPromoter(PromoterId promoterId, Instant from, Instant to);
 }

--- a/src/main/java/com/gresk/modules/event/infrastructure/persistence/CalendarEventMapper.java
+++ b/src/main/java/com/gresk/modules/event/infrastructure/persistence/CalendarEventMapper.java
@@ -1,0 +1,29 @@
+package com.gresk.modules.event.infrastructure.persistence;
+
+import com.gresk.modules.event.domain.model.CalendarEvent;
+import com.gresk.modules.event.domain.model.EventId;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CalendarEventMapper {
+
+    public CalendarEvent toDomain(EventEntity e) {
+        int soldPercentage = 0;
+        if (e.getTotalCapacity() != null && e.getTotalCapacity() > 0) {
+            int available = e.getAvailableCapacity() != null ? e.getAvailableCapacity() : 0;
+            soldPercentage = (int) Math.round(
+                    (e.getTotalCapacity() - available) / (double) e.getTotalCapacity() * 100
+            );
+        }
+        return new CalendarEvent(
+                EventId.of(e.getId().toString()),
+                e.getTitle(),
+                e.getEventDate(),
+                e.getStatus(),
+                soldPercentage,
+                e.getGenre(),
+                e.getCity(),
+                e.getVenue()
+        );
+    }
+}

--- a/src/main/java/com/gresk/modules/event/infrastructure/persistence/EventJpaRepository.java
+++ b/src/main/java/com/gresk/modules/event/infrastructure/persistence/EventJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -48,4 +49,17 @@ public interface EventJpaRepository
             ORDER BY event_date ASC
             """, nativeQuery = true)
     List<EventEntity> findEligibleForFlashDeal();
+
+    @Query("""
+            SELECT e FROM EventEntity e
+            WHERE e.promoterId = :promoterId
+              AND e.eventDate >= :from
+              AND e.eventDate < :to
+            ORDER BY e.eventDate ASC
+            """)
+    List<EventEntity> findByPromoterAndDateRange(
+            @Param("promoterId") UUID promoterId,
+            @Param("from") Instant from,
+            @Param("to") Instant to
+    );
 }

--- a/src/main/java/com/gresk/modules/event/infrastructure/persistence/JpaEventAdapter.java
+++ b/src/main/java/com/gresk/modules/event/infrastructure/persistence/JpaEventAdapter.java
@@ -1,14 +1,17 @@
 package com.gresk.modules.event.infrastructure.persistence;
 
+import com.gresk.modules.event.domain.model.CalendarEvent;
 import com.gresk.modules.event.domain.model.Event;
 import com.gresk.modules.event.domain.model.EventId;
 import com.gresk.modules.event.domain.port.out.EventFilter;
 import com.gresk.modules.event.domain.port.out.EventRepository;
+import com.gresk.modules.promoter.domain.model.valueobject.PromoterId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,6 +22,7 @@ public class JpaEventAdapter implements EventRepository {
 
     private final EventJpaRepository repo;
     private final EventMapper mapper;
+    private final CalendarEventMapper calendarMapper;
 
     @Override
     @Transactional
@@ -64,6 +68,14 @@ public class JpaEventAdapter implements EventRepository {
         return repo.findEligibleForFlashDeal()
                 .stream()
                 .map(mapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<CalendarEvent> findCalendarEventsByPromoter(PromoterId promoterId, Instant from, Instant to) {
+        return repo.findByPromoterAndDateRange(promoterId.value(), from, to)
+                .stream()
+                .map(calendarMapper::toDomain)
                 .toList();
     }
 }

--- a/src/main/java/com/gresk/modules/event/infrastructure/web/EventController.java
+++ b/src/main/java/com/gresk/modules/event/infrastructure/web/EventController.java
@@ -1,13 +1,20 @@
 package com.gresk.modules.event.infrastructure.web;
 
+import com.gresk.modules.event.application.dto.CalendarEventsResponse;
+import com.gresk.modules.event.application.dto.CalendarResponseMapper;
 import com.gresk.modules.event.application.dto.EventResponse;
 import com.gresk.modules.event.application.dto.EventResponseMapper;
+import com.gresk.modules.event.application.dto.HeatmapResponse;
 import com.gresk.modules.event.application.dto.PageResponse;
+import com.gresk.modules.event.application.query.CalendarEventsQuery;
 import com.gresk.modules.event.application.query.GetEventQuery;
+import com.gresk.modules.event.application.query.HeatmapQuery;
 import com.gresk.modules.event.application.query.ListEventsQuery;
 import com.gresk.modules.event.application.usecase.CreateEventCommand;
 import com.gresk.modules.event.application.usecase.CreateEventUseCase;
+import com.gresk.modules.event.application.usecase.GetCalendarEventsUseCase;
 import com.gresk.modules.event.application.usecase.GetEventUseCase;
+import com.gresk.modules.event.application.usecase.GetHeatmapUseCase;
 import com.gresk.modules.event.application.usecase.GetLastMinuteEventsUseCase;
 import com.gresk.modules.event.application.usecase.ListEventsUseCase;
 import com.gresk.modules.event.application.usecase.PublishEventUseCase;
@@ -17,6 +24,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -26,6 +34,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 
 @Slf4j
@@ -40,7 +50,10 @@ public class EventController {
     private final ListEventsUseCase          listUseCase;
     private final GetLastMinuteEventsUseCase getLastMinuteUseCase;
     private final UpdateFlashDealUseCase     updateFlashDealUseCase;
+    private final GetCalendarEventsUseCase   getCalendarEventsUseCase;
+    private final GetHeatmapUseCase          getHeatmapUseCase;
     private final EventResponseMapper        mapper;
+    private final CalendarResponseMapper     calendarMapper;
 
     // ── POST /api/v1/events ──────────────────────────────────────────────────
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -138,5 +151,32 @@ public class EventController {
                 request.flashDealDiscountPercent()
         );
         return ResponseEntity.ok(mapper.toResponse(updateFlashDealUseCase.execute(command)));
+    }
+
+    // ── GET /api/v1/events/calendar ──────────────────────────────────────────
+    @GetMapping("/calendar")
+    @PreAuthorize("hasRole('PROMOTER')")
+    public ResponseEntity<CalendarEventsResponse> getCalendar(
+            @AuthenticationPrincipal String promoterId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+
+        Instant fromInstant = from.atStartOfDay(ZoneOffset.UTC).toInstant();
+        Instant toInstant   = to.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+        CalendarEventsQuery query = new CalendarEventsQuery(promoterId, fromInstant, toInstant);
+        return ResponseEntity.ok(calendarMapper.toCalendarResponse(getCalendarEventsUseCase.execute(query)));
+    }
+
+    // ── GET /api/v1/events/calendar/heatmap ──────────────────────────────────
+    @GetMapping("/calendar/heatmap")
+    @PreAuthorize("hasRole('PROMOTER')")
+    public ResponseEntity<HeatmapResponse> getHeatmap(
+            @AuthenticationPrincipal String promoterId,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        HeatmapQuery query = new HeatmapQuery(promoterId, year, month);
+        return ResponseEntity.ok(calendarMapper.toHeatmapResponse(year, month, getHeatmapUseCase.execute(query)));
     }
 }

--- a/src/main/resources/db/migration/V5__create_events.sql
+++ b/src/main/resources/db/migration/V5__create_events.sql
@@ -14,7 +14,7 @@
 --   flash deal: flash_deal_enabled, flash_deal_hours_threshold,
 --               flash_deal_discount_percent, flash_deal_applied
 --
--- EventStatus enum: DRAFT, PUBLISHED, FINISHED, CANCELLED
+-- EventStatus enum: DRAFT, PUBLISHED, SOLD_OUT, FINISHED, CANCELLED
 -- MusicGenre enum: ROCK, POP, TECHNO, REGGAETON, HIP_HOP, HOUSE, INDIE,
 --                  METAL, TRAP, JAZZ, CLASSICAL, FLAMENCO, R_AND_B,
 --                  PUNK, LATIN_JAZZ, ELECTRONIC, SURPRISE
@@ -71,7 +71,7 @@ CREATE TABLE events (
     CONSTRAINT pk_events              PRIMARY KEY (id),
     CONSTRAINT fk_events_promoter     FOREIGN KEY (promoter_id) REFERENCES promoters (id) ON DELETE RESTRICT,
     CONSTRAINT fk_events_artist       FOREIGN KEY (artist_id)   REFERENCES artists  (id) ON DELETE SET NULL,
-    CONSTRAINT chk_events_status      CHECK (status IN ('DRAFT', 'PUBLISHED', 'FINISHED', 'CANCELLED')),
+    CONSTRAINT chk_events_status      CHECK (status IN ('DRAFT', 'PUBLISHED', 'SOLD_OUT', 'FINISHED', 'CANCELLED')),
     CONSTRAINT chk_events_genre       CHECK (genre IN (
         'ROCK', 'POP', 'TECHNO', 'REGGAETON', 'HIP_HOP', 'HOUSE',
         'INDIE', 'METAL', 'TRAP', 'JAZZ', 'CLASSICAL', 'FLAMENCO',
@@ -84,6 +84,7 @@ CREATE INDEX idx_events_status       ON events (status);
 CREATE INDEX idx_events_genre_status ON events (genre, status);
 CREATE INDEX idx_events_city_date    ON events (city, event_date);
 CREATE INDEX idx_events_artist_id    ON events (artist_id);
+CREATE INDEX idx_events_promoter_date ON events (promoter_id, event_date);
 
 -- Partial index: cubre únicamente los candidatos del scheduler flash deal.
 -- El WHERE estrecho mantiene el índice pequeño independientemente del volumen de eventos.


### PR DESCRIPTION
- Añade SOLD_OUT a EventStatus con transiciones automáticas desde decrementCapacity()
- restoreCapacity() revierte SOLD_OUT → PUBLISHED al liberar plaza
- Proyecciones CalendarEvent y HeatmapDay para vistas ligeras del calendario
- GET /api/v1/events/calendar — vista mensual/semanal de eventos propios (PROMOTER)
- GET /api/v1/events/calendar/heatmap — heatmap de ocupación día a día (PROMOTER)
- Índice compuesto (promoter_id, event_date) para consultas del calendario
- Extiende el módulo event/ sin crear módulo nuevo